### PR TITLE
Add service option 'ExternalTrafficPolicy'

### DIFF
--- a/nix/lib.nix
+++ b/nix/lib.nix
@@ -179,6 +179,8 @@ let
       } // (optionalAttrs (port.nodePort != null) {
         nodePort = port.nodePort;
       }))) service.ports;
+    }) // (optionalAttrs (service.externalTrafficPolicy != null) {
+      externalTrafficPolicy = service.externalTrafficPolicy;
     });
   };
 

--- a/nix/options.nix
+++ b/nix/options.nix
@@ -536,6 +536,12 @@ let
         default = null;
       };
 
+      externalTrafficPolicy = mkOption {
+        description = "External traffic policy";
+        type = types.nullOr (types.enum [ "Local" "Cluster" ]);
+        default = null;
+      };
+
       ports = mkOption {
         type = types.listOf types.optionSet;
         description = "Ports exposed by service";


### PR DESCRIPTION
Hey, since kubernetes 1.7 we are supposed to use service.spec.externalTrafficPolicy to control how external traffic accesses the cluster service.  Since we updated kubernetes on nix to 1.7.1 we should probably use it.  This patch enables nix-kubernetes users to use this option.  If there are aspects of this patch you don't like, please tell me :)