### PR TITLE
Make updateStrategy for daemonSets customizable

### DIFF
--- a/nix/lib.nix
+++ b/nix/lib.nix
@@ -155,8 +155,11 @@ let
 
   mkDaemonSetSpec = daemon: {
     spec = {
-      template = (mkSpecMeta daemon.pod) // (mkPodSpec daemon.pod);
-    };
+      template = (mkSpecMeta daemon.pod) // (mkPodSpec daemon.pod
+      );
+    } // (optionalAttrs (daemon.updateStrategy != null) {
+      updateStrategy = daemon.updateStrategy;
+    });
   };
 
   mkServiceSpec = service: {

--- a/nix/options.nix
+++ b/nix/options.nix
@@ -475,6 +475,11 @@ let
           default = {};
         };
       };
+      updateStrategy = mkOption {
+        description = "Update strategy for the daemonset.";
+        type = with types; nullOr (attrsOf (either str (attrsOf str)));
+        default = null;
+      };
     };
 
     config = mkMerge [{


### PR DESCRIPTION
This patch makes it possible to configure the update strategy for kubernetes daemonsets.  I very much welcome feedback, if you want aspects of this PR changed.