### PR TITLE
examples/trivial.nix: fix for b054dbd7

### DIFF
--- a/examples/trivial.nix
+++ b/examples/trivial.nix
@@ -1,6 +1,6 @@
 {
   default = {
-    kubernetes.namespace.name = "default";
+    kubernetes.defaultNamespace = "default";
 
     # Elasticserach replication controller
     kubernetes.controllers.elasticsearch = {


### PR DESCRIPTION
namespace.name has been renamed to defaultNamespace, it seems.