### PR TITLE
default.nix: remove profiles value

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -45,8 +45,6 @@ in
 	with pkgs.lib;
   with (import (builtins.fetchTarball https://github.com/moretea/yarn2nix/archive/master.tar.gz) { inherit pkgs; });
 {
-  inherit profiles;
-
   package = mkYarnPackage {
     name = "nix-kubernetes-${version}";
     src = ./.;


### PR DESCRIPTION
default.nix didn't work on my 17.09 system. Where was it supposed to come from and what is it for? Feel free to decline this PR.